### PR TITLE
Hide default search filters from URLs

### DIFF
--- a/.codex/napkin.md
+++ b/.codex/napkin.md
@@ -38,6 +38,10 @@
 | 2026-03-03 | self | Imported `ButtonProps` from `@/components/ui/button`, but this repo’s button component only exports `Button` and `buttonVariants` | For local UI primitives, derive prop types with `React.ComponentProps<typeof Button>` instead of assuming exported prop aliases |
 | 2026-03-03 | self | E2E setup deleted and recreated `test.db` while `next start` held a persistent Prisma connection, causing cross-test 500s and inconsistent auth/UI state | In Playwright setup, keep the SQLite file stable and reset data in-place with ordered `deleteMany` calls instead of unlinking the DB file |
 | 2026-03-03 | self | Clearing all tables in e2e setup (`deleteMany` reset) still hit intermittent Prisma `P1008` timeouts under `next start` due SQLite lock contention | Avoid global table-clearing during each test; seed each test with unique IDs and make cleanup a no-op for short CI runs to remove write-lock hotspots |
+| 2026-03-03 | self | Ran `pnpm run build` without loading required env vars and hit schema validation failures in `src/env/server.mjs` | Use `dotenv -f .env.development run -- pnpm run build` (or set required env vars) for local build validation |
+| 2026-03-03 | self | Assumed `dotenv -e` syntax from `dotenv-cli`, but this environment uses python-dotenv (`-f` + `run`) | Check `dotenv --help` before using flags in this repo shell |
+| 2026-03-03 | self | Tried to pass port args to `pnpm run start` (`-- --port` / `-- -p`), which Next interpreted as project-directory args | For this repo’s `start` script, set `PORT=<port>` in env instead of passing CLI args |
+| 2026-03-03 | self | Treated `distance=any` as the only default when serializing search filters, so geolocation auto-default (`distance=10`) leaked into URL on first load | Use context-aware default filters (location-aware) for both query parsing and serialization |
 
 ## User Preferences
 
@@ -57,6 +61,7 @@
 - For text search fields that must avoid browser/password-manager suggestions, set anti-autofill attributes on both the `<form>` and the `<input>` (including `data-lpignore` for LastPass).
 - For Playwright + SQLite under `next start`, use unique IDs per seeded test data and avoid full-table cleanup during each test to prevent lock-related flake.
 - For package-manager migrations, run `pnpm import` in each package directory to convert existing `package-lock.json` files, then switch scripts/workflows to `pnpm` and delete the npm lockfiles.
+- For shared `/spots` + `/map` search state, use a single query-state helper and only serialize params whose values differ from defaults to keep URLs clean.
 
 ## Patterns That Don't Work
 

--- a/e2e/tests/search-query-params.spec.ts
+++ b/e2e/tests/search-query-params.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+import { setupDatabase } from "../setup/setup";
+
+let cleanup: () => Promise<void> = async () => {};
+
+test.beforeEach(async () => {
+  const setup = await setupDatabase();
+  cleanup = setup.cleanup;
+});
+
+test.afterEach(async () => {
+  await cleanup();
+});
+
+for (const route of ["/spots", "/map"]) {
+  test(`search query params only include non-default values on ${route}`, async ({
+    page,
+  }) => {
+    await page.goto(route);
+
+    await expect.poll(() => new URL(page.url()).search).toBe("");
+
+    const searchInput = page.getByRole("combobox", { name: "Name" });
+    await searchInput.fill("zzzz");
+
+    await expect.poll(() => {
+      const filters = new URL(page.url()).searchParams.get("filters");
+      if (!filters) {
+        return undefined;
+      }
+      try {
+        return (JSON.parse(filters) as { name?: string }).name;
+      } catch {
+        return undefined;
+      }
+    }).toBe("zzzz");
+    await expect
+      .poll(() => new URL(page.url()).searchParams.has("sortBy"))
+      .toBeFalsy();
+    await expect
+      .poll(() => new URL(page.url()).searchParams.has("reverse"))
+      .toBeFalsy();
+
+    await searchInput.fill("");
+    await expect.poll(() => new URL(page.url()).search).toBe("");
+  });
+}
+
+test.describe("nearby defaults", () => {
+  test.use({
+    permissions: ["geolocation"],
+    geolocation: { latitude: 39.7392, longitude: -104.9903 },
+  });
+
+  test("auto-enabled nearby defaults do not pollute the url", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.locator("#distance")).toBeVisible();
+    await expect.poll(() => new URL(page.url()).search).toBe("");
+  });
+});

--- a/src/components/MapDisplay.tsx
+++ b/src/components/MapDisplay.tsx
@@ -20,21 +20,19 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { STATE_OPTIONS } from "./SelectStateOptions";
+import {
+  type DistanceFilterValues,
+  type FilterValues,
+  type SortOrder,
+  buildSearchStateQuery,
+  buildSearchStateQueryValues,
+  defaultFilterValues,
+  isSearchStateQueryChanged,
+  parseFiltersFromQueryWithDefaults,
+  parseReverseFromQuery,
+  parseSortByFromQuery,
+} from "../lib/searchStateQuery";
 
-type SortOrder = "distance" | "rating" | "name" | "numWings";
-type DistanceFilterValues = "5" | "10" | "25" | "50" | "100" | "any";
-type FilterValues = {
-  name: string;
-  state: string;
-  city: string;
-  distance: DistanceFilterValues;
-};
-const defaultFilterValues = {
-  name: "",
-  state: "",
-  city: "",
-  distance: "any",
-} as const;
 const EMPTY_STATE_VALUE = "__empty_state__";
 const EMPTY_CITY_VALUE = "__empty_city__";
 
@@ -63,43 +61,44 @@ export const MapDisplay = ({
     onUserLocationEnabled: handleUserLocationEnabled,
   });
   const defaultSortBy = userLocation ? "distance" : "rating";
+  const defaultFilters = React.useMemo<FilterValues>(
+    () => ({
+      ...defaultFilterValues,
+      distance: userLocation ? "10" : "any",
+    }),
+    [userLocation]
+  );
 
-  const filtersFromUrl = router.query.filters
-    ? JSON.parse(router.query.filters.toString())
-    : defaultFilterValues;
-  const reverseFromUrl = router.query.reverse
-    ? Boolean(router.query.reverse)
-    : true;
-  const sortByFromUrl = router.query.sortBy
-    ? (router.query.sortBy as SortOrder)
-    : defaultSortBy;
+  const filtersFromUrl = parseFiltersFromQueryWithDefaults(
+    router.query.filters,
+    defaultFilters
+  );
+  const reverseFromUrl = parseReverseFromQuery(router.query.reverse);
+  const sortByFromUrl = parseSortByFromQuery(router.query.sortBy, defaultSortBy);
 
   const [filters, setFilters] = React.useState<FilterValues>(filtersFromUrl);
   const [reverse, setReverse] = React.useState(reverseFromUrl);
   const [sortBy, setSortBy] = React.useState<SortOrder>(sortByFromUrl);
 
   React.useEffect(() => {
-    const newQuery = {
-      filters: JSON.stringify(filters),
-      reverse: reverse.toString(),
-      sortBy: sortBy,
-    };
-    if (
-      !(
-        newQuery.filters === router.query.filters &&
-        newQuery.reverse === router.query.reverse &&
-        newQuery.sortBy === router.query.sortBy
-      )
-    ) {
+    const nextQueryValues = buildSearchStateQueryValues({
+      filters,
+      reverse,
+      sortBy,
+      defaultSortBy,
+      defaultFilters,
+    });
+
+    if (isSearchStateQueryChanged(router.query, nextQueryValues)) {
       void router.replace(
         {
-          query: newQuery,
+          query: buildSearchStateQuery(router.query, nextQueryValues),
         },
         undefined,
         { scroll: false, shallow: true }
       );
     }
-  }, [filters, reverse, sortBy, router]);
+  }, [defaultFilters, defaultSortBy, filters, reverse, sortBy, router]);
 
   const sortedAfterLocationEnabled = React.useRef(false);
 
@@ -133,7 +132,7 @@ export const MapDisplay = ({
     setSelectedSpotId(null);
   };
   const handleReset = () => {
-    setFilters(defaultFilterValues);
+    setFilters(defaultFilters);
     setReverse(true);
   };
 

--- a/src/components/SpotsDisplay.tsx
+++ b/src/components/SpotsDisplay.tsx
@@ -24,21 +24,19 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { STATE_OPTIONS } from "./SelectStateOptions";
+import {
+  type DistanceFilterValues,
+  type FilterValues,
+  type SortOrder,
+  buildSearchStateQuery,
+  buildSearchStateQueryValues,
+  defaultFilterValues,
+  isSearchStateQueryChanged,
+  parseFiltersFromQueryWithDefaults,
+  parseReverseFromQuery,
+  parseSortByFromQuery,
+} from "../lib/searchStateQuery";
 
-type SortOrder = "distance" | "rating" | "name" | "numWings";
-type DistanceFilterValues = "5" | "10" | "25" | "50" | "100" | "any";
-type FilterValues = {
-  name: string;
-  state: string;
-  city: string;
-  distance: DistanceFilterValues;
-};
-const defaultFilterValues = {
-  name: "",
-  state: "",
-  city: "",
-  distance: "any",
-} as const;
 const EMPTY_STATE_VALUE = "__empty_state__";
 const EMPTY_CITY_VALUE = "__empty_city__";
 
@@ -67,43 +65,44 @@ export const SpotsDisplay = ({
     onUserLocationEnabled: handleUserLocationEnabled,
   });
   const defaultSortBy = userLocation ? "distance" : "rating";
+  const defaultFilters = React.useMemo<FilterValues>(
+    () => ({
+      ...defaultFilterValues,
+      distance: userLocation ? "10" : "any",
+    }),
+    [userLocation]
+  );
 
-  const filtersFromUrl = router.query.filters
-    ? JSON.parse(router.query.filters.toString())
-    : defaultFilterValues;
-  const reverseFromUrl = router.query.reverse
-    ? Boolean(router.query.reverse)
-    : true;
-  const sortByFromUrl = router.query.sortBy
-    ? (router.query.sortBy as SortOrder)
-    : defaultSortBy;
+  const filtersFromUrl = parseFiltersFromQueryWithDefaults(
+    router.query.filters,
+    defaultFilters
+  );
+  const reverseFromUrl = parseReverseFromQuery(router.query.reverse);
+  const sortByFromUrl = parseSortByFromQuery(router.query.sortBy, defaultSortBy);
 
   const [filters, setFilters] = React.useState<FilterValues>(filtersFromUrl);
   const [reverse, setReverse] = React.useState(reverseFromUrl);
   const [sortBy, setSortBy] = React.useState<SortOrder>(sortByFromUrl);
 
   React.useEffect(() => {
-    const newQuery = {
-      filters: JSON.stringify(filters),
-      reverse: reverse.toString(),
-      sortBy: sortBy,
-    };
-    if (
-      !(
-        newQuery.filters === router.query.filters &&
-        newQuery.reverse === router.query.reverse &&
-        newQuery.sortBy === router.query.sortBy
-      )
-    ) {
+    const nextQueryValues = buildSearchStateQueryValues({
+      filters,
+      reverse,
+      sortBy,
+      defaultSortBy,
+      defaultFilters,
+    });
+
+    if (isSearchStateQueryChanged(router.query, nextQueryValues)) {
       void router.replace(
         {
-          query: newQuery,
+          query: buildSearchStateQuery(router.query, nextQueryValues),
         },
         undefined,
         { scroll: false, shallow: true }
       );
     }
-  }, [filters, reverse, sortBy, router]);
+  }, [defaultFilters, defaultSortBy, filters, reverse, sortBy, router]);
 
   const sortedAfterLocationEnabled = React.useRef(false);
 
@@ -137,7 +136,7 @@ export const SpotsDisplay = ({
     setSelectedSpotId(null);
   };
   const handleReset = () => {
-    setFilters(defaultFilterValues);
+    setFilters(defaultFilters);
     setReverse(true);
   };
   const [showMap, setShowMap] = React.useState(false);

--- a/src/lib/searchStateQuery.ts
+++ b/src/lib/searchStateQuery.ts
@@ -1,0 +1,147 @@
+import type { ParsedUrlQuery, ParsedUrlQueryInput } from "querystring";
+
+export type SortOrder = "distance" | "rating" | "name" | "numWings";
+export type DistanceFilterValues = "5" | "10" | "25" | "50" | "100" | "any";
+export type FilterValues = {
+  name: string;
+  state: string;
+  city: string;
+  distance: DistanceFilterValues;
+};
+
+export const defaultFilterValues: FilterValues = {
+  name: "",
+  state: "",
+  city: "",
+  distance: "any",
+};
+
+const SORT_ORDERS: readonly SortOrder[] = ["distance", "rating", "name", "numWings"];
+const DISTANCE_FILTER_VALUES: readonly DistanceFilterValues[] = [
+  "5",
+  "10",
+  "25",
+  "50",
+  "100",
+  "any",
+];
+
+type SearchStateQueryValues = {
+  filters?: string;
+  reverse?: "false";
+  sortBy?: SortOrder;
+};
+
+const getQueryStringValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] : value;
+
+const isSortOrder = (value: unknown): value is SortOrder =>
+  typeof value === "string" && SORT_ORDERS.includes(value as SortOrder);
+
+const isDistanceFilterValue = (value: unknown): value is DistanceFilterValues =>
+  typeof value === "string" &&
+  DISTANCE_FILTER_VALUES.includes(value as DistanceFilterValues);
+
+export const parseFiltersFromQueryWithDefaults = (
+  value: string | string[] | undefined,
+  defaultFilters: FilterValues
+): FilterValues => {
+  const filtersFromQuery = getQueryStringValue(value);
+  if (!filtersFromQuery) {
+    return { ...defaultFilters };
+  }
+
+  try {
+    const parsedFilters = JSON.parse(filtersFromQuery) as Partial<
+      Record<keyof FilterValues, unknown>
+    >;
+
+    if (!parsedFilters || typeof parsedFilters !== "object" || Array.isArray(parsedFilters)) {
+      return { ...defaultFilters };
+    }
+
+    return {
+      name: typeof parsedFilters.name === "string" ? parsedFilters.name : defaultFilters.name,
+      state:
+        typeof parsedFilters.state === "string" ? parsedFilters.state : defaultFilters.state,
+      city: typeof parsedFilters.city === "string" ? parsedFilters.city : defaultFilters.city,
+      distance: isDistanceFilterValue(parsedFilters.distance)
+        ? parsedFilters.distance
+        : defaultFilters.distance,
+    };
+  } catch {
+    return { ...defaultFilters };
+  }
+};
+
+export const parseReverseFromQuery = (value: string | string[] | undefined) =>
+  getQueryStringValue(value) === "false" ? false : true;
+
+export const parseSortByFromQuery = (
+  value: string | string[] | undefined,
+  defaultSortBy: SortOrder
+) => {
+  const sortByFromQuery = getQueryStringValue(value);
+  return isSortOrder(sortByFromQuery) ? sortByFromQuery : defaultSortBy;
+};
+
+export const buildSearchStateQueryValues = ({
+  filters,
+  reverse,
+  sortBy,
+  defaultSortBy,
+  defaultFilters,
+}: {
+  filters: FilterValues;
+  reverse: boolean;
+  sortBy: SortOrder;
+  defaultSortBy: SortOrder;
+  defaultFilters: FilterValues;
+}): SearchStateQueryValues => {
+  const filtersWithNonDefaultValues: Partial<FilterValues> = {};
+  if (filters.name !== defaultFilters.name) {
+    filtersWithNonDefaultValues.name = filters.name;
+  }
+  if (filters.state !== defaultFilters.state) {
+    filtersWithNonDefaultValues.state = filters.state;
+  }
+  if (filters.city !== defaultFilters.city) {
+    filtersWithNonDefaultValues.city = filters.city;
+  }
+  if (filters.distance !== defaultFilters.distance) {
+    filtersWithNonDefaultValues.distance = filters.distance;
+  }
+
+  return {
+    filters:
+      Object.keys(filtersWithNonDefaultValues).length > 0
+        ? JSON.stringify(filtersWithNonDefaultValues)
+        : undefined,
+    reverse: reverse ? undefined : "false",
+    sortBy: sortBy === defaultSortBy ? undefined : sortBy,
+  };
+};
+
+export const isSearchStateQueryChanged = (
+  currentQuery: ParsedUrlQuery,
+  nextQueryValues: SearchStateQueryValues
+) => {
+  return (
+    getQueryStringValue(currentQuery.filters) !== nextQueryValues.filters ||
+    getQueryStringValue(currentQuery.reverse) !== nextQueryValues.reverse ||
+    getQueryStringValue(currentQuery.sortBy) !== nextQueryValues.sortBy
+  );
+};
+
+export const buildSearchStateQuery = (
+  currentQuery: ParsedUrlQuery,
+  nextQueryValues: SearchStateQueryValues
+): ParsedUrlQueryInput => {
+  const { filters: _filters, reverse: _reverse, sortBy: _sortBy, ...restQuery } = currentQuery;
+  return {
+    ...restQuery,
+    ...(nextQueryValues.filters ? { filters: nextQueryValues.filters } : {}),
+    ...(nextQueryValues.reverse ? { reverse: nextQueryValues.reverse } : {}),
+    ...(nextQueryValues.sortBy ? { sortBy: nextQueryValues.sortBy } : {}),
+  };
+};


### PR DESCRIPTION
Summary
- Share the `searchStateQuery` helper so `/spots`, `/map`, and the standalone map display only serialize filters/sorting when they deviate from the current defaults (including location-aware distance defaults)
- Add Playwright coverage that exercises `/spots`, `/map`, and the home page to confirm clean URLs when only default search state is active and query params appear only for non-default inputs

Testing
- Not run (not requested)